### PR TITLE
include_numeric_format: emit minimum/maximum for int32/int64

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ protoc \
 |`enforce_oneof`| Interpret Proto "oneOf" clauses |
 |`enums_as_strings_only`| Only include strings in the allowed values for enums |
 |`file_extension`| Specify a custom file extension for generated schemas |
-|`include_numeric_format`| Include OAS formats for numeric types |
+|`include_numeric_format`| Include OAS formats for numeric types, plus `minimum`/`maximum` bounds for int32/int64 (and uint32). UINT64/FIXED64 keep format-only — see PR comment. |
 |`json_fieldnames`| Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |
 |`proto_and_json_fieldnames`| Use proto and JSON field names |

--- a/internal/converter/testdata/numeric_format.go
+++ b/internal/converter/testdata/numeric_format.go
@@ -7,6 +7,8 @@ const NumericFormat = `{
         "NumericFormat": {
             "properties": {
                 "int_val": {
+                    "maximum": 2147483647,
+                    "minimum": -2147483648,
                     "type": "integer",
                     "format": "int32"
                 },
@@ -24,6 +26,8 @@ const NumericFormat = `{
                 },
                 "int_val_array": {
                     "items": {
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
                         "type": "integer",
                         "format": "int32"
                     },

--- a/internal/converter/testdata/numeric_format_bigint_as_string.go
+++ b/internal/converter/testdata/numeric_format_bigint_as_string.go
@@ -7,10 +7,14 @@ const NumericFormatBigIntAsString = `{
         "NumericFormat": {
             "properties": {
                 "int_val": {
+                    "maximum": 2147483647,
+                    "minimum": -2147483648,
                     "type": "integer",
                     "format": "int32"
                 },
                 "long_val": {
+                    "maximum": 9223372036854775807,
+                    "minimum": -9223372036854775808,
                     "type": "integer",
                     "format": "int64"
                 },
@@ -24,6 +28,8 @@ const NumericFormatBigIntAsString = `{
                 },
                 "int_val_array": {
                     "items": {
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
                         "type": "integer",
                         "format": "int32"
                     },
@@ -31,6 +37,8 @@ const NumericFormatBigIntAsString = `{
                 },
                 "long_val_array": {
                     "items": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
                         "type": "integer",
                         "format": "int64"
                     },

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/alecthomas/jsonschema"
@@ -129,17 +130,29 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			}
 		}
 
-	// Int32:
+	// Int32 family:
 	case descriptor.FieldDescriptorProto_TYPE_INT32,
 		descriptor.FieldDescriptorProto_TYPE_UINT32,
 		descriptor.FieldDescriptorProto_TYPE_FIXED32,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED32,
 		descriptor.FieldDescriptorProto_TYPE_SINT32:
+
+		// Pick bounds based on the specific 32-bit type. Signed and unsigned
+		// share this case but have different valid ranges.
+		var minBound, maxBound int
+		switch desc.GetType() {
+		case descriptor.FieldDescriptorProto_TYPE_UINT32,
+			descriptor.FieldDescriptorProto_TYPE_FIXED32:
+			minBound, maxBound = 0, math.MaxUint32
+		default:
+			minBound, maxBound = math.MinInt32, math.MaxInt32
+		}
+
 		if messageFlags.AllowNullValues {
 			if c.Flags.IncludeNumericFormat {
 				jsonSchemaType.OneOf = []*jsonschema.Type{
 					{Type: gojsonschema.TYPE_NULL},
-					{Type: gojsonschema.TYPE_INTEGER, Format: "int32"},
+					{Type: gojsonschema.TYPE_INTEGER, Format: "int32", Minimum: minBound, Maximum: maxBound},
 				}
 			} else {
 				jsonSchemaType.OneOf = []*jsonschema.Type{
@@ -151,22 +164,43 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
 			if c.Flags.IncludeNumericFormat {
 				jsonSchemaType.Format = "int32"
+				jsonSchemaType.Minimum = minBound
+				jsonSchemaType.Maximum = maxBound
 			}
 		}
 
-	// Int64:
+	// Int64 family:
 	case descriptor.FieldDescriptorProto_TYPE_INT64,
 		descriptor.FieldDescriptorProto_TYPE_UINT64,
 		descriptor.FieldDescriptorProto_TYPE_FIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SINT64:
 
-		// As integer:
+		// Pick bounds. UINT64 / FIXED64 max (2^64-1) overflows the signed `int`
+		// field on alecthomas/jsonschema.Type, so we skip bounds for those and
+		// keep format-only behavior. Signed 64-bit gets full bounds.
+		var minBound, maxBound int
+		hasBounds := false
+		switch desc.GetType() {
+		case descriptor.FieldDescriptorProto_TYPE_UINT64,
+			descriptor.FieldDescriptorProto_TYPE_FIXED64:
+			// bounds intentionally omitted — see comment above
+		default:
+			minBound, maxBound = math.MinInt64, math.MaxInt64
+			hasBounds = true
+		}
+
+		// As integer (when callers set disallow_bigints_as_strings):
 		if c.Flags.DisallowBigIntsAsStrings {
 			if messageFlags.AllowNullValues {
 				if c.Flags.IncludeNumericFormat {
+					intType := &jsonschema.Type{Type: gojsonschema.TYPE_INTEGER, Format: "int64"}
+					if hasBounds {
+						intType.Minimum = minBound
+						intType.Maximum = maxBound
+					}
 					jsonSchemaType.OneOf = []*jsonschema.Type{
-						{Type: gojsonschema.TYPE_INTEGER, Format: "int64"},
+						intType,
 						{Type: gojsonschema.TYPE_NULL},
 					}
 				} else {
@@ -179,6 +213,10 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 				jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
 				if c.Flags.IncludeNumericFormat {
 					jsonSchemaType.Format = "int64"
+					if hasBounds {
+						jsonSchemaType.Minimum = minBound
+						jsonSchemaType.Maximum = maxBound
+					}
 				}
 			}
 		}
@@ -345,7 +383,11 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Items.Type = jsonSchemaType.Type
 			jsonSchemaType.Items.OneOf = jsonSchemaType.OneOf
 			jsonSchemaType.Items.Format = jsonSchemaType.Format
+			jsonSchemaType.Items.Minimum = jsonSchemaType.Minimum
+			jsonSchemaType.Items.Maximum = jsonSchemaType.Maximum
 			jsonSchemaType.Format = ""
+			jsonSchemaType.Minimum = 0
+			jsonSchemaType.Maximum = 0
 		}
 
 		if messageFlags.AllowNullValues {


### PR DESCRIPTION
Extends `include_numeric_format` so that when callers opt in, generated JSON Schemas carry explicit `minimum`/`maximum` bounds in addition to the existing `format` annotation.

## Why

JSON Schema Draft V7's `format` keyword is annotation-only — `networknt/json-schema-validator` and other Draft V7 validators don't enforce it. The existing `format: int32` emission documents the intended numeric width but does not actually catch out-of-range values. This results in a recurring class of `Long.parseLong` overflow bugs in downstream pipelines where producers send values outside int32 range against int32-typed fields.

Bounds are the enforceable form of the same information. With `minimum`/`maximum` present, networknt (Jackson + BigDecimal under the hood) compares values precisely against the bound — including across the full int64 range, since Jackson reads large integers as `BigInteger`/`BigDecimal` with no precision loss.

## What changes

Generated JSON Schemas (when `include_numeric_format` is enabled) now include:

| protobuf type | `format` | `minimum` | `maximum` |
|---|---|---|---|
| `int32` / `sfixed32` / `sint32` | `int32` | `-2147483648` | `2147483647` |
| `uint32` / `fixed32` | `int32` | `0` | `4294967295` |
| `int64` / `sfixed64` / `sint64` (integer-mode) | `int64` | `-9223372036854775808` | `9223372036854775807` |
| `uint64` / `fixed64` | `int64` | _(omitted — see follow-up comment)_ | _(omitted)_ |
| `float` | `float` | _(unchanged)_ | _(unchanged)_ |
| `double` | `double` | _(unchanged)_ | _(unchanged)_ |

Bounds propagate to `items` for repeated fields. `format` emission is unchanged in all cases (kept as a documentation/IDE hint).

## Test changes

- `internal/converter/testdata/numeric_format.go` — int32 properties (and their array items) now include `minimum`/`maximum`. `long_val` (which is in string-mode here because `disallow_bigints_as_strings` defaults off) is unchanged.
- `internal/converter/testdata/numeric_format_bigint_as_string.go` — both int32 and int64 properties (and their array items) now include `minimum`/`maximum`.

Both `NumericFormat` and `NumericFormatBigIntAsString` table-tests pass. Float/double goldens are untouched.

## Pre-existing test failures (not introduced here)

`go test ./internal/converter` shows 4 failures on `main` that also reproduce here:

- `GoogleInt64ValueAllowNull`
- `GoogleInt64ValueDisallowStringAllowNull`
- `ValidationOptions`
- `WellKnown`

All are protobuf wrapper / well-known-type descriptor comparisons against goldens captured under an older `protoc`. Modern `protoc` (34.1) emits richer `description` strings (e.g. `"Not recommended for use in new APIs..."` was appended to `Int64Value`'s doc comment upstream). Unrelated to this change.

## Background

Posted as draft pending discussion of the option-surface decision and the punted numeric cases — see the follow-up comment below.

---

Marking draft so we can iterate on the option surface and the scope-cut decisions before you merge. Happy to rework as `include_numeric_bounds` (separate option) if you prefer that to extending `include_numeric_format` — see comment.