### PR TITLE
Add include_numeric_bounds option for protobuf scalar bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ protoc \
 |`enums_as_strings_only`| Only include strings in the allowed values for enums |
 |`file_extension`| Specify a custom file extension for generated schemas |
 |`include_numeric_format`| Include OAS formats for numeric types |
+|`include_numeric_bounds`| Emit `minimum`/`maximum` matching each numeric scalar's protobuf range (int32 ±2³¹−1, uint32 0–2³²−1, int64 ±2⁶³−1, uint64 0–2⁶⁴−1, float/double IEEE 754 finite extremes). int64-class fields are skipped when emitted as JSON strings (proto3 default); pair with `disallow_bigints_as_strings` to apply 64-bit bounds. |
 |`json_fieldnames`| Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |
 |`proto_and_json_fieldnames`| Use proto and JSON field names |

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -56,6 +56,7 @@ type ConverterFlags struct {
 	EnumsAsStringsOnly           bool
 	EnumsTrimPrefix              bool
 	IncludeNumericFormat         bool
+	IncludeNumericBounds         bool
 	KeepNewLinesInDescription    bool
 	PrefixSchemaFilesWithPackage bool
 	UseJSONFieldnamesOnly        bool
@@ -118,6 +119,8 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 			c.Flags.UseJSONFieldnamesOnly = true
 		case "include_numeric_format":
 			c.Flags.IncludeNumericFormat = true
+		case "include_numeric_bounds":
+			c.Flags.IncludeNumericBounds = true
 		case "prefix_schema_files_with_package":
 			c.Flags.PrefixSchemaFilesWithPackage = true
 		case "proto_and_json_fieldnames":

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -342,6 +342,18 @@ func configureSampleProtos() map[string]sampleProto {
 			FilesToGenerate:       []string{"NumericFormat.proto"},
 			ProtoFileName:         "NumericFormat.proto",
 		},
+		"NumericBounds": {
+			Flags:                 ConverterFlags{IncludeNumericBounds: true},
+			ExpectedJSONSchema:    []string{testdata.NumericBounds},
+			FilesToGenerate:       []string{"NumericBounds.proto"},
+			ProtoFileName:         "NumericBounds.proto",
+		},
+		"NumericBoundsBigIntAsString": {
+			Flags:                 ConverterFlags{IncludeNumericBounds: true, DisallowBigIntsAsStrings: true},
+			ExpectedJSONSchema:    []string{testdata.NumericBoundsBigIntAsString},
+			FilesToGenerate:       []string{"NumericBounds.proto"},
+			ProtoFileName:         "NumericBounds.proto",
+		},
 		"OneOf": {
 			Flags:                 ConverterFlags{AllFieldsRequired: true, EnforceOneOf: true},
 			ExpectedJSONSchema:    []string{testdata.OneOf},

--- a/internal/converter/testdata/numeric_bounds.go
+++ b/internal/converter/testdata/numeric_bounds.go
@@ -1,0 +1,65 @@
+package testdata
+
+const NumericBounds = `{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/NumericBounds",
+    "$defs": {
+        "NumericBounds": {
+            "properties": {
+                "int32_val": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": -2147483648
+                },
+                "sint32_val": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": -2147483648
+                },
+                "sfixed32_val": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": -2147483648
+                },
+                "uint32_val": {
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
+                },
+                "fixed32_val": {
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
+                },
+                "int64_val": {
+                    "type": "string"
+                },
+                "sint64_val": {
+                    "type": "string"
+                },
+                "sfixed64_val": {
+                    "type": "string"
+                },
+                "uint64_val": {
+                    "type": "string"
+                },
+                "fixed64_val": {
+                    "type": "string"
+                },
+                "float_val": {
+                    "type": "number",
+                    "maximum": 3.4028234663852886e+38,
+                    "minimum": -3.4028234663852886e+38
+                },
+                "double_val": {
+                    "type": "number",
+                    "maximum": 1.7976931348623157e+308,
+                    "minimum": -1.7976931348623157e+308
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Numeric Bounds"
+        }
+    }
+}`

--- a/internal/converter/testdata/numeric_bounds_bigint_as_string.go
+++ b/internal/converter/testdata/numeric_bounds_bigint_as_string.go
@@ -1,0 +1,75 @@
+package testdata
+
+const NumericBoundsBigIntAsString = `{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/NumericBounds",
+    "$defs": {
+        "NumericBounds": {
+            "properties": {
+                "int32_val": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": -2147483648
+                },
+                "sint32_val": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": -2147483648
+                },
+                "sfixed32_val": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": -2147483648
+                },
+                "uint32_val": {
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
+                },
+                "fixed32_val": {
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
+                },
+                "int64_val": {
+                    "type": "integer",
+                    "maximum": 9223372036854775807,
+                    "minimum": -9223372036854775808
+                },
+                "sint64_val": {
+                    "type": "integer",
+                    "maximum": 9223372036854775807,
+                    "minimum": -9223372036854775808
+                },
+                "sfixed64_val": {
+                    "type": "integer",
+                    "maximum": 9223372036854775807,
+                    "minimum": -9223372036854775808
+                },
+                "uint64_val": {
+                    "type": "integer",
+                    "maximum": 18446744073709551615,
+                    "minimum": 0
+                },
+                "fixed64_val": {
+                    "type": "integer",
+                    "maximum": 18446744073709551615,
+                    "minimum": 0
+                },
+                "float_val": {
+                    "type": "number",
+                    "maximum": 3.4028234663852886e+38,
+                    "minimum": -3.4028234663852886e+38
+                },
+                "double_val": {
+                    "type": "number",
+                    "maximum": 1.7976931348623157e+308,
+                    "minimum": -1.7976931348623157e+308
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Numeric Bounds"
+        }
+    }
+}`

--- a/internal/converter/testdata/proto/NumericBounds.proto
+++ b/internal/converter/testdata/proto/NumericBounds.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+package samples;
+
+message NumericBounds {
+    int32 int32_val       = 1;
+    sint32 sint32_val     = 2;
+    sfixed32 sfixed32_val = 3;
+    uint32 uint32_val     = 4;
+    fixed32 fixed32_val   = 5;
+    int64 int64_val       = 6;
+    sint64 sint64_val     = 7;
+    sfixed64 sfixed64_val = 8;
+    uint64 uint64_val     = 9;
+    fixed64 fixed64_val   = 10;
+    float float_val       = 11;
+    double double_val     = 12;
+}

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -1,6 +1,7 @@
 package converter
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -118,6 +119,9 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 				jsonSchemaType.Format = "float"
 			}
 		}
+		if c.Flags.IncludeNumericBounds {
+			applyNumericBounds(jsonSchemaType, desc.GetType())
+		}
 
 	// Double:
 	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
@@ -138,6 +142,9 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			if c.Flags.IncludeNumericFormat {
 				jsonSchemaType.Format = "double"
 			}
+		}
+		if c.Flags.IncludeNumericBounds {
+			applyNumericBounds(jsonSchemaType, desc.GetType())
 		}
 
 	// Int32:
@@ -163,6 +170,9 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			if c.Flags.IncludeNumericFormat {
 				jsonSchemaType.Format = "int32"
 			}
+		}
+		if c.Flags.IncludeNumericBounds {
+			applyNumericBounds(jsonSchemaType, desc.GetType())
 		}
 
 	// Int64:
@@ -214,6 +224,9 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 					jsonSchemaType.Format = "int64"
 				}
 			}
+		}
+		if c.Flags.IncludeNumericBounds {
+			applyNumericBounds(jsonSchemaType, desc.GetType())
 		}
 
 	// String:
@@ -356,7 +369,11 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Items.Type = jsonSchemaType.Type
 			jsonSchemaType.Items.OneOf = jsonSchemaType.OneOf
 			jsonSchemaType.Items.Format = jsonSchemaType.Format
+			jsonSchemaType.Items.Minimum = jsonSchemaType.Minimum
+			jsonSchemaType.Items.Maximum = jsonSchemaType.Maximum
 			jsonSchemaType.Format = ""
+			jsonSchemaType.Minimum = ""
+			jsonSchemaType.Maximum = ""
 		}
 
 		if messageFlags.AllowNullValues {
@@ -818,4 +835,60 @@ func schemaAllowAny() *jsonschema.Schema {
 // additional properties.
 func schemaAllowNone() *jsonschema.Schema {
 	return jsonschema.FalseSchema
+}
+
+// numericBounds returns the inclusive (minimum, maximum) pair for a protobuf
+// numeric scalar type. The bool indicates whether the type is numeric at all.
+//
+// Bound values are encoded as json.Number string literals so that uint64's
+// 2^64-1 and float64's ±1.8e308 round-trip without lossy conversion through a
+// Go int (which would overflow on 32-bit hosts) or a float64 (which can only
+// approximate the 64-bit integer extremes).
+func numericBounds(protoType descriptor.FieldDescriptorProto_Type) (min, max json.Number, ok bool) {
+	switch protoType {
+	case descriptor.FieldDescriptorProto_TYPE_FLOAT:
+		return "-3.4028234663852886e+38", "3.4028234663852886e+38", true
+	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
+		return "-1.7976931348623157e+308", "1.7976931348623157e+308", true
+	case descriptor.FieldDescriptorProto_TYPE_INT32,
+		descriptor.FieldDescriptorProto_TYPE_SINT32,
+		descriptor.FieldDescriptorProto_TYPE_SFIXED32:
+		return "-2147483648", "2147483647", true
+	case descriptor.FieldDescriptorProto_TYPE_UINT32,
+		descriptor.FieldDescriptorProto_TYPE_FIXED32:
+		return "0", "4294967295", true
+	case descriptor.FieldDescriptorProto_TYPE_INT64,
+		descriptor.FieldDescriptorProto_TYPE_SINT64,
+		descriptor.FieldDescriptorProto_TYPE_SFIXED64:
+		return "-9223372036854775808", "9223372036854775807", true
+	case descriptor.FieldDescriptorProto_TYPE_UINT64,
+		descriptor.FieldDescriptorProto_TYPE_FIXED64:
+		return "0", "18446744073709551615", true
+	}
+	return "", "", false
+}
+
+// applyNumericBounds attaches minimum/maximum to a schema produced for a
+// protobuf numeric scalar. For nullable fields the schema is a OneOf of null +
+// the typed branch, and bounds are applied to the typed branch. The string
+// variant of int64-class fields (proto3's default JSON encoding) is skipped:
+// JSON Schema numeric bounds apply only to integer/number-typed schemas.
+func applyNumericBounds(schema *jsonschema.Schema, protoType descriptor.FieldDescriptorProto_Type) {
+	min, max, ok := numericBounds(protoType)
+	if !ok {
+		return
+	}
+	if len(schema.OneOf) > 0 {
+		for _, branch := range schema.OneOf {
+			if branch.Type == jsTypeInteger || branch.Type == jsTypeNumber {
+				branch.Minimum = min
+				branch.Maximum = max
+			}
+		}
+		return
+	}
+	if schema.Type == jsTypeInteger || schema.Type == jsTypeNumber {
+		schema.Minimum = min
+		schema.Maximum = max
+	}
 }


### PR DESCRIPTION
## Summary

Adds a new opt-in generator parameter, `include_numeric_bounds`, that emits JSON Schema `minimum` and `maximum` matching the protobuf range for every numeric scalar:

| proto type | min | max |
|---|---|---|
| `int32` / `sint32` / `sfixed32` | −2³¹ | 2³¹−1 |
| `uint32` / `fixed32` | 0 | 2³²−1 |
| `int64` / `sint64` / `sfixed64` | −2⁶³ | 2⁶³−1 |
| `uint64` / `fixed64` | 0 | 2⁶⁴−1 |
| `float` | −3.4028234663852886e+38 | 3.4028234663852886e+38 |
| `double` | −1.7976931348623157e+308 | 1.7976931348623157e+308 |

Kept independent of the existing `include_numeric_format` option. Either, both, or neither can be enabled. `include_numeric_format` is annotation-only (validators ignore it); `include_numeric_bounds` carries semantic constraints downstream validators (networknt, ajv, etc.) actually enforce.

This is the follow-on to PR #7 (invopop migration), enabled by invopop's `Minimum`/`Maximum` being typed `json.Number` — alecthomas typed those as Go `int`, which couldn't represent uint64 or any float value.

Closes / supersedes #6 (the int32/int64-only version against alecthomas), #5 (David's parallel attempt against alecthomas), and #4 (the original int_range PR).

## Caveats

**Go int type-fit:** the 64-bit ranges (−2⁶³ and 2⁶⁴−1 in particular) don't fit a signed Go `int` on 32-bit hosts and 2⁶⁴−1 doesn't fit any signed Go integer at all. Bounds are therefore encoded as `json.Number` string literals (`"-9223372036854775808"`, `"18446744073709551615"`) rather than parsed numeric constants. Same approach for float/double — `"3.4028234663852886e+38"` round-trips exactly without going through a Go `float64` intermediate.

**int64 dual-emission:** per the proto3 JSON spec, int64-class fields default to JSON string encoding. JSON Schema `minimum`/`maximum` apply only to integer/number-typed schemas, not strings. So when emitted as strings (the default), `include_numeric_bounds` leaves them alone. Pair with `disallow_bigints_as_strings` to apply 64-bit bounds on the integer-typed schema. Both modes covered by the new tests.

## Tests

Two new fixtures exercise all twelve numeric variants:
- `NumericBounds` — `IncludeNumericBounds: true`, default int64 encoding. 32-bit and float/double fields carry bounds; int64-class fields are emitted as strings without bounds.
- `NumericBoundsBigIntAsString` — `IncludeNumericBounds: true` + `DisallowBigIntsAsStrings: true`. All twelve variants carry bounds.

All existing goldens unchanged. `go test ./...` is green.

## Test plan

- [x] All twelve protobuf numeric scalar variants emit `minimum`/`maximum` when option enabled
- [x] int64-class fields skip bounds in string mode (proto3 default)
- [x] int64-class fields apply 64-bit bounds when paired with `disallow_bigints_as_strings`
- [x] Repeated numeric fields propagate bounds into `items`
- [x] Existing tests pass unchanged (option is opt-in)